### PR TITLE
feat: task FP.3 define class MessageQueue

### DIFF
--- a/src/TrafficLight.cpp
+++ b/src/TrafficLight.cpp
@@ -3,7 +3,6 @@
 #include "TrafficLight.h"
 
 /* Implementation of class "MessageQueue" */
-
 /*
 template <typename T>
 T MessageQueue<T>::receive()

--- a/src/TrafficLight.h
+++ b/src/TrafficLight.h
@@ -9,6 +9,11 @@
 // forward declarations to avoid include cycle
 class Vehicle;
 
+enum TrafficLightPhase
+{
+    red,
+    green,
+};
 
 // FP.3 Define a class „MessageQueue“ which has the public methods send and receive. 
 // Send should take an rvalue reference of type TrafficLightPhase whereas receive should return this type. 
@@ -19,9 +24,12 @@ template <class T>
 class MessageQueue
 {
 public:
-
+    void send(TrafficLightPhase &&lightPhase);
+    TrafficLightPhase receive();
 private:
-    
+    std::deque<TrafficLightPhase> _queue;
+    std::condition_variable _condition;
+    std::mutex _mutex;
 };
 
 // FP.1 : Define a class „TrafficLight“ which is a child class of TrafficObject. 
@@ -29,11 +37,6 @@ private:
 // as well as „TrafficLightPhase getCurrentPhase()“, where TrafficLightPhase is an enum that 
 // can be either „red“ or „green“. Also, add the private method „void cycleThroughPhases()“. 
 // Furthermore, there shall be the private member _currentPhase which can take „red“ or „green“ as its value. 
-enum TrafficLightPhase
-{
-    red,
-    green,
-};
 
 class TrafficLight : public TrafficObject
 {


### PR DESCRIPTION
Task FP.3 : Define a class MessageQueue which has the public methods send and receive. Send should take an rvalue reference of type TrafficLightPhase whereas receive should return this type. Also, the class should define an std::dequeue called _queue, which stores objects of type TrafficLightPhase. Finally, there should be an std::condition_variable as well as an std::mutex as private members