### PR TITLE
feat: Task FP.4, implemented messagequeue on TrafficLight

### DIFF
--- a/src/TrafficLight.cpp
+++ b/src/TrafficLight.cpp
@@ -85,7 +85,7 @@ void TrafficLight::cycleThroughPhases()
             // 3. Toggle between red and green
                 _currentPhase = _currentPhase == TrafficLightPhase::red ? TrafficLightPhase::green : TrafficLightPhase::red;
             // 4. Send update message to queue
-                //TODO: move current phase when messageQueue is implemented in FP.3/FP.4
+                _lightPhaseMsgs.send(std::move(_currentPhase));
             // 5. reset stop watch for next cycle
             lastUpdate = std::chrono::system_clock::now();
         }

--- a/src/TrafficLight.h
+++ b/src/TrafficLight.h
@@ -58,6 +58,7 @@ private:
     // and use it within the infinite loop to push each new TrafficLightPhase into it by calling 
     // send in conjunction with move semantics.
     TrafficLightPhase _currentPhase;
+    MessageQueue _lightPhaseMsgs;
     std::condition_variable _condition;
     std::mutex _mutex;
 };


### PR DESCRIPTION
Implemented: in class TrafficLight, create a private member of type MessageQueue for messages of type TrafficLightPhase and use it within the infinite loop to push each new TrafficLightPhase into it by calling send in conjunction with move semantics.