### PR TITLE
feat: task FP.5 implement TrafficLight class methods receive and wait…

### DIFF
--- a/src/TrafficLight.cpp
+++ b/src/TrafficLight.cpp
@@ -53,6 +53,13 @@ void TrafficLight::waitForGreen()
     // FP.5b : add the implementation of the method waitForGreen, in which an infinite while-loop 
     // runs and repeatedly calls the receive function on the message queue. 
     // Once it receives TrafficLightPhase::green, the method returns.
+    while(true)
+    {
+        if(_lightPhaseMsgs.receive() == TrafficLightPhase::green)
+            return; 
+        // sleep at every iteration to reduce CPU usage
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
 }
 
 TrafficLightPhase TrafficLight::getCurrentPhase()

--- a/src/TrafficLight.h
+++ b/src/TrafficLight.h
@@ -57,8 +57,8 @@ private:
     // FP.4b : create a private member of type MessageQueue for messages of type TrafficLightPhase 
     // and use it within the infinite loop to push each new TrafficLightPhase into it by calling 
     // send in conjunction with move semantics.
-    TrafficLightPhase _currentPhase;
     MessageQueue _lightPhaseMsgs;
+    TrafficLightPhase _currentPhase;
     std::condition_variable _condition;
     std::mutex _mutex;
 };


### PR DESCRIPTION
…ForGreen

Task FP.5 : The method receive should use std::unique_lock<std::mutex> and _condition.wait() to wait for and receive new messages and pull them from the queue using move semantics. The received object should then be returned by the receive function. Then, add the implementation of the method waitForGreen, in which an infinite while-loop runs and repeatedly calls the receive function on the message queue. Once it receives TrafficLightPhase::green, the method returns.