### PR TITLE
feat: task FP.6 implement traffic lights on intersections

### DIFF
--- a/src/Intersection.cpp
+++ b/src/Intersection.cpp
@@ -87,7 +87,9 @@ void Intersection::addVehicleToQueue(std::shared_ptr<Vehicle> vehicle)
     std::cout << "Intersection #" << _id << ": Vehicle #" << vehicle->getID() << " is granted entry." << std::endl;
     
     // FP.6b : use the methods TrafficLight::getCurrentPhase and TrafficLight::waitForGreen to block the execution until the traffic light turns green.
-
+    if(_trafficLight.getCurrentPhase() == TrafficLightPhase::red)
+        _trafficLight.waitForGreen();
+        
     lck.unlock();
 }
 
@@ -109,7 +111,7 @@ void Intersection::setIsBlocked(bool isBlocked)
 void Intersection::simulate() // using threads + promises/futures + exceptions
 {
     // FP.6a : In Intersection.h, add a private member _trafficLight of type TrafficLight. At this position, start the simulation of _trafficLight.
-
+    _trafficLight.simulate();
     // launch vehicle queue processing in a thread
     threads.emplace_back(std::thread(&Intersection::processVehicleQueue, this));
 }

--- a/src/Intersection.h
+++ b/src/Intersection.h
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <memory>
 #include "TrafficObject.h"
+#include "TrafficLight.h" //FP.6: include the class; no need of forward declaration is required in this case.
 
 // forward declarations to avoid include cycle
 class Street;
@@ -54,6 +55,8 @@ private:
     std::vector<std::shared_ptr<Street>> _streets;   // list of all streets connected to this intersection
     WaitingVehicles _waitingVehicles; // list of all vehicles and their associated promises waiting to enter the intersection
     bool _isBlocked;                  // flag indicating wether the intersection is blocked by a vehicle
+    // FP.6a : In Intersection.h, add a private member _trafficLight of type TrafficLight.
+    TrafficLight _trafficLight;
 };
 
 #endif

--- a/src/TrafficLight.cpp
+++ b/src/TrafficLight.cpp
@@ -98,11 +98,11 @@ void TrafficLight::cycleThroughPhases()
     while (true){
         // 2. Compute time difference to stop watch
         long elapsedTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - lastUpdate).count();
-        if (elapsedTime > phaseDuration) {
+        if (elapsedTime >= phaseDuration) {
             // 3. Toggle between red and green
-                _currentPhase = _currentPhase == TrafficLightPhase::red ? TrafficLightPhase::green : TrafficLightPhase::red;
+            _currentPhase = _currentPhase == TrafficLightPhase::red ? TrafficLightPhase::green : TrafficLightPhase::red;
             // 4. Send update message to queue
-                _lightPhaseMsgs.send(std::move(_currentPhase));
+            _lightPhaseMsgs.send(std::move(_currentPhase));
             // 5. reset stop watch for next cycle
             lastUpdate = std::chrono::system_clock::now();
         }


### PR DESCRIPTION
Task FP.6 : In class Intersection, add a private member _trafficLight of type TrafficLight. In method Intersection::simulate(), start the simulation of _trafficLight. Then, in method Intersection::addVehicleToQueue, use the methods TrafficLight::getCurrentPhase and TrafficLight::waitForGreen to block the execution until the traffic light turns green.