### PR TITLE
fix: debug in VS Code (crashes)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "g++ - Build and debug active file",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/traffic_simulation",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ],
+            //"preLaunchTask": "C/C++: g++ build active file",
+            //"miDebuggerPath": "/usr/bin/gdb"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+    "tasks": [
+        {
+            "type": "shell",
+            "label": "C/C++: g++ build active file",
+            "command": "/usr/bin/g++",
+            "args": [
+                "-g",
+                "${file}",
+                "-o",
+                "${fileDirname}/${fileBasenameNoExtension}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ],
+    "version": "2.0.0"
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: all
+all: format test build
+
+.PHONY: format
+format:
+	clang-format src/* include/* -i
+
+.PHONY: build
+build:
+	mkdir -p build
+	cd build && \
+	cmake .. && \
+	make
+
+.PHONY: debug
+debug:
+	mkdir -p build
+	cd build && \
+	cmake -DCMAKE_BUILD_TYPE=debug .. && \
+	make
+
+.PHONY: clean
+clean:
+	rm -rf build


### PR DESCRIPTION
Fix cannot debug on VS Code.\n - Added launch configuration on VSCode.\n - Added new Makefile with 'make debug' configuration.\n NOTE: Debug crashes, attempts to open the window but fails due to missing files.