### PR TITLE
clean-up and set t-lights to defaults

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,10 +20,8 @@
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true
-                }
+                },
             ],
-            //"preLaunchTask": "C/C++: g++ build active file",
-            //"miDebuggerPath": "/usr/bin/gdb"
         }
     ]
 }

--- a/src/Intersection.cpp
+++ b/src/Intersection.cpp
@@ -95,7 +95,7 @@ void Intersection::addVehicleToQueue(std::shared_ptr<Vehicle> vehicle)
 
 void Intersection::vehicleHasLeft(std::shared_ptr<Vehicle> vehicle)
 {
-    //std::cout << "Intersection #" << _id << ": Vehicle #" << vehicle->getID() << " has left." << std::endl;
+    std::cout << "Intersection #" << _id << ": Vehicle #" << vehicle->getID() << " has left." << std::endl;
 
     // unblock queue processing
     this->setIsBlocked(false);
@@ -146,5 +146,4 @@ bool Intersection::trafficLightIsGreen()
        return true;
    else
        return false;
-  //return true; // makes traffic light permanently green
 } 

--- a/src/Intersection.h
+++ b/src/Intersection.h
@@ -6,7 +6,7 @@
 #include <mutex>
 #include <memory>
 #include "TrafficObject.h"
-#include "TrafficLight.h" //FP.6: include the class; no need of forward declaration is required in this case.
+#include "TrafficLight.h" 
 
 // forward declarations to avoid include cycle
 class Street;
@@ -24,7 +24,7 @@ public:
     void permitEntryToFirstInQueue();
 
 private:
-    std::vector<std::shared_ptr<Vehicle>> _vehicles;          // list of all vehicles waiting to enter this intersection
+    std::vector<std::shared_ptr<Vehicle>> _vehicles; // list of all vehicles waiting to enter this intersection
     std::vector<std::promise<void>> _promises; // list of associated promises
     std::mutex _mutex;
 };

--- a/src/TrafficLight.h
+++ b/src/TrafficLight.h
@@ -20,8 +20,6 @@ enum TrafficLightPhase
 // Also, the class should define an std::dequeue called _queue, which stores objects of type TrafficLightPhase. 
 // Also, there should be an std::condition_variable as well as an std::mutex as private members. 
 
-// FP3: not used as a template!     
-// FP7 using a template (all types renamed to T, 'lightPhase' variable to 'msg')
 template <class T> 
 class MessageQueue
 {


### PR DESCRIPTION
clean-up some commented code/comments. But still all task descriptions have been left to ease correction. \n The traffic lights phase random values have been set to default 4-6 seconds. However some strange behaviors may show up if these values are set to large values, e.g. 5-20 seconds.